### PR TITLE
카풀 HTTP 메서드 수정 및 카풀 이용 목록 수정

### DIFF
--- a/logs/application-logging-2025-03-03.0.log
+++ b/logs/application-logging-2025-03-03.0.log
@@ -1,0 +1,123 @@
+2025-03-03 02:16:30 [INFO] o.h.v.i.u.Version - HV000001: Hibernate Validator 8.0.1.Final
+2025-03-03 02:16:30 [INFO] M.C.CarpoolApplication - Starting CarpoolApplication using Java 17.0.10 with PID 34475 (/Users/jeonminseo/Downloads/Carpool_Last/out/production/classes started by jeonminseo in /Users/jeonminseo/Downloads/Carpool_Last)
+2025-03-03 02:16:30 [INFO] M.C.CarpoolApplication - No active profile set, falling back to 1 default profile: "default"
+2025-03-03 02:16:31 [INFO] o.s.d.r.c.RepositoryConfigurationDelegate - Multiple Spring Data modules found, entering strict repository configuration mode
+2025-03-03 02:16:31 [INFO] o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2025-03-03 02:16:31 [INFO] o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 78 ms. Found 4 JPA repository interfaces.
+2025-03-03 02:16:31 [INFO] o.s.d.r.c.RepositoryConfigurationDelegate - Multiple Spring Data modules found, entering strict repository configuration mode
+2025-03-03 02:16:31 [INFO] o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data Redis repositories in DEFAULT mode.
+2025-03-03 02:16:31 [INFO] o.s.d.r.c.RepositoryConfigurationExtensionSupport - Spring Data Redis - Could not safely identify store assignment for repository candidate interface MATE.Carpool.domain.carpool.repository.CarpoolRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
+2025-03-03 02:16:31 [INFO] o.s.d.r.c.RepositoryConfigurationExtensionSupport - Spring Data Redis - Could not safely identify store assignment for repository candidate interface MATE.Carpool.domain.carpool.repository.ReservationRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
+2025-03-03 02:16:31 [INFO] o.s.d.r.c.RepositoryConfigurationExtensionSupport - Spring Data Redis - Could not safely identify store assignment for repository candidate interface MATE.Carpool.domain.member.repository.MemberRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
+2025-03-03 02:16:31 [INFO] o.s.d.r.c.RepositoryConfigurationExtensionSupport - Spring Data Redis - Could not safely identify store assignment for repository candidate interface MATE.Carpool.domain.report.repository.ReportRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
+2025-03-03 02:16:31 [INFO] o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 5 ms. Found 0 Redis repository interfaces.
+2025-03-03 02:16:32 [INFO] o.s.b.w.e.t.TomcatWebServer - Tomcat initialized with port 8080 (http)
+2025-03-03 02:16:32 [INFO] o.a.c.h.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
+2025-03-03 02:16:32 [INFO] o.a.c.c.StandardService - Starting service [Tomcat]
+2025-03-03 02:16:32 [INFO] o.a.c.c.StandardEngine - Starting Servlet engine: [Apache Tomcat/10.1.33]
+2025-03-03 02:16:32 [INFO] o.a.c.c.C.[.[.[/] - Initializing Spring embedded WebApplicationContext
+2025-03-03 02:16:32 [INFO] o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 1373 ms
+2025-03-03 02:16:32 [INFO] c.z.h.HikariDataSource - HikariPool-1 - Starting...
+2025-03-03 02:16:32 [INFO] c.z.h.p.HikariPool - HikariPool-1 - Added connection conn0: url=jdbc:h2:mem:test user=SA
+2025-03-03 02:16:32 [INFO] c.z.h.HikariDataSource - HikariPool-1 - Start completed.
+2025-03-03 02:16:32 [INFO] o.s.b.a.h.H2ConsoleAutoConfiguration - H2 console available at '/h2-console'. Database available at 'jdbc:h2:mem:test'
+2025-03-03 02:16:32 [INFO] o.h.j.i.u.LogHelper - HHH000204: Processing PersistenceUnitInfo [name: default]
+2025-03-03 02:16:32 [INFO] o.h.Version - HHH000412: Hibernate ORM core version 6.6.2.Final
+2025-03-03 02:16:32 [INFO] o.h.c.i.RegionFactoryInitiator - HHH000026: Second-level cache disabled
+2025-03-03 02:16:32 [INFO] o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
+2025-03-03 02:16:32 [WARN] o.h.o.deprecation - HHH90000025: H2Dialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2025-03-03 02:16:32 [INFO] o.h.o.c.pooling - HHH10001005: Database info:
+	Database JDBC URL [Connecting through datasource 'HikariDataSource (HikariPool-1)']
+	Database driver: undefined/unknown
+	Database version: 2.3.232
+	Autocommit mode: undefined/unknown
+	Isolation level: undefined/unknown
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2025-03-03 02:16:33 [INFO] o.h.e.t.j.p.i.JtaPlatformInitiator - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2025-03-03 02:16:33 [INFO] o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
+2025-03-03 02:16:33 [INFO] o.s.d.j.r.q.QueryEnhancerFactory - Hibernate is in classpath; If applicable, HQL parser will be used.
+2025-03-03 02:16:33 [ERROR] i.n.r.d.DnsServerAddressStreamProviders - Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS. Check whether you have a dependency on 'io.netty:netty-resolver-dns-native-macos'. Use DEBUG level to see the full stack: java.lang.UnsatisfiedLinkError: failed to load the required native library
+2025-03-03 02:16:34 [WARN] o.s.b.a.o.j.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2025-03-03 02:16:34 [INFO] o.s.s.c.a.a.c.InitializeUserDetailsBeanManagerConfigurer$InitializeUserDetailsManagerConfigurer - Global AuthenticationManager configured with UserDetailsService bean with name customUserDetailsServiceImpl
+2025-03-03 02:16:35 [INFO] o.s.b.a.e.w.EndpointLinksResolver - Exposing 1 endpoint beneath base path '/actuator'
+2025-03-03 02:16:35 [INFO] o.a.c.h.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
+2025-03-03 02:16:35 [INFO] o.s.b.w.e.t.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
+2025-03-03 02:16:35 [INFO] M.C.CarpoolApplication - Started CarpoolApplication in 5.258 seconds (process running for 5.503)
+2025-03-03 02:16:35 [INFO] M.C.c.a.LoggingAspect - Join : IP : [Unknown] / Method : [run] / Args : [[[]]]
+2025-03-03 02:17:38 [INFO] o.a.c.c.C.[.[.[/] - Initializing Spring DispatcherServlet 'dispatcherServlet'
+2025-03-03 02:17:38 [INFO] o.s.w.s.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
+2025-03-03 02:17:38 [INFO] o.s.w.s.DispatcherServlet - Completed initialization in 3 ms
+2025-03-03 02:17:38 [INFO] M.C.c.a.LoggingAspect - Join : IP : [0:0:0:0:0:0:0:1] / Method : [signIn] / Args : [[SignInRequestDto{memberId='testr1', password='[PROTECTED]'}, org.springframework.web.context.request.async.StandardServletAsyncWebRequest$LifecycleHttpServletResponse@5649d0ff, org.springframework.web.servlet.resource.ResourceUrlEncodingFilter$ResourceUrlEncodingRequestWrapper@52d8d521]]
+2025-03-03 02:17:38 [ERROR] M.C.c.a.LoggingAspect - Error : IP : [0:0:0:0:0:0:0:1] / Method : [signIn] / Exception : [org.springframework.security.authentication.InternalAuthenticationServiceException]
+2025-03-03 02:17:54 [INFO] M.C.c.a.LoggingAspect - Join : IP : [0:0:0:0:0:0:0:1] / Method : [signIn] / Args : [[SignInRequestDto{memberId='tester1', password='[PROTECTED]'}, org.springframework.web.context.request.async.StandardServletAsyncWebRequest$LifecycleHttpServletResponse@2e56dc06, org.springframework.web.servlet.resource.ResourceUrlEncodingFilter$ResourceUrlEncodingRequestWrapper@2ed92240]]
+2025-03-03 02:17:54 [INFO] M.C.c.a.LoggingAspect - Return : IP : [0:0:0:0:0:0:0:1] / Method : [signIn] / Status : [200 OK] / Returned : [Message(message=로그인, status=200 OK, data=MemberResponseDto(isDriver=true, isBanned=false, carpoolCount=0))]
+2025-03-03 02:18:48 [INFO] M.C.c.a.LoggingAspect - Join : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester1] / Method : [makeCarpool] / Args : [CarpoolRequestDTO(departureCoordinate=경기도 수원시 권선구 오목천동, latitude=37.566826, longitude=126.9786567, departureTime=2025-03-03T07:05:29.288, chatLink=kakao.com, capacity=4, cost=2000)]
+2025-03-03 02:18:48 [INFO] M.C.c.a.LoggingAspect - Return : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester1] / Method : [makeCarpool] / Status : [200 OK] / Returned : [Message(message=카풀 생성 성공, status=200 OK, data=CarpoolResponseDTO(carpoolId=1, driverName=tester1, driverImg=https://carool-s3.s3.ap-northeast-2.amazonaws.com/profileImgS3.png, carImg=https://carool-s3.s3.ap-northeast-2.amazonaws.com/profileImgS3.png, carNumber=1가 1234, departureCoordinate=경기도 수원시 권선구 오목천동, latitude=null, longitude=null, departureTime=2025-03-03T07:05:29.288, chatLink=kakao.com, capacity=4, cost=2000, reservationCount=0))]
+2025-03-03 02:18:56 [INFO] M.C.c.a.LoggingAspect - Join : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester1] / Method : [myCarpool] / Args : []
+2025-03-03 02:18:56 [INFO] M.C.c.a.LoggingAspect - Return : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester1] / Method : [myCarpool] / Status : [200 OK] / Returned : [Message(message=내 카풀 조회, status=200 OK, data=MATE.Carpool.domain.carpool.dto.response.CarpoolWithPassengersDTO@56d2b7f2)]
+2025-03-03 02:19:25 [INFO] M.C.c.a.LoggingAspect - Join : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester1] / Method : [getDriverHistory] / Args : []
+2025-03-03 02:19:25 [INFO] M.C.c.a.LoggingAspect - Return : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester1] / Method : [getDriverHistory] / Status : [200 OK] / Returned : [Message(message=운행 목록 조회 성공, status=200 OK, data=[])]
+2025-03-03 02:19:43 [INFO] M.C.c.a.LoggingAspect - Join : IP : [0:0:0:0:0:0:0:1] / Method : [signIn] / Args : [[SignInRequestDto{memberId='tester2', password='[PROTECTED]'}, org.springframework.web.context.request.async.StandardServletAsyncWebRequest$LifecycleHttpServletResponse@2c6c9577, org.springframework.web.servlet.resource.ResourceUrlEncodingFilter$ResourceUrlEncodingRequestWrapper@7c4061a9]]
+2025-03-03 02:19:43 [INFO] M.C.c.a.LoggingAspect - Return : IP : [0:0:0:0:0:0:0:1] / Method : [signIn] / Status : [200 OK] / Returned : [Message(message=로그인, status=200 OK, data=MemberResponseDto(isDriver=false, isBanned=false, carpoolCount=0))]
+2025-03-03 02:19:54 [INFO] M.C.c.a.LoggingAspect - Join : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester2] / Method : [myCarpool] / Args : []
+2025-03-03 02:19:54 [ERROR] M.C.c.a.LoggingAspect - Error : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester2] / Method : [myCarpool] / Exception : [MATE.Carpool.common.exception.CustomException]
+2025-03-03 02:20:10 [INFO] M.C.c.a.LoggingAspect - Join : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester2] / Method : [myCarpool] / Args : []
+2025-03-03 02:20:10 [ERROR] M.C.c.a.LoggingAspect - Error : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester2] / Method : [myCarpool] / Exception : [MATE.Carpool.common.exception.CustomException]
+2025-03-03 02:20:16 [INFO] M.C.c.a.LoggingAspect - Join : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester1] / Method : [getDriverHistory] / Args : []
+2025-03-03 02:20:16 [INFO] M.C.c.a.LoggingAspect - Return : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester1] / Method : [getDriverHistory] / Status : [200 OK] / Returned : [Message(message=운행 목록 조회 성공, status=200 OK, data=[])]
+2025-03-03 02:20:39 [INFO] M.C.c.a.LoggingAspect - Join : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester1] / Method : [getCarpoolHistory] / Args : []
+2025-03-03 02:20:39 [INFO] M.C.c.a.LoggingAspect - Return : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester1] / Method : [getCarpoolHistory] / Status : [200 OK] / Returned : [Message(message=탑승 목록 조회 성공, status=200 OK, data=[])]
+2025-03-03 02:21:30 [INFO] M.C.c.a.LoggingAspect - Join : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester2] / Method : [reservationCarpool] / Args : [MATE.Carpool.domain.carpool.dto.request.ReservationCarpoolRequestDTO@55e46388]
+2025-03-03 02:21:30 [INFO] M.C.c.a.LoggingAspect - Return : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester2] / Method : [reservationCarpool] / Status : [200 OK] / Returned : [Message(message=카풀 예약 성공, status=200 OK, data=1)]
+2025-03-03 02:21:36 [INFO] M.C.c.a.LoggingAspect - Join : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester2] / Method : [myCarpool] / Args : []
+2025-03-03 02:21:36 [INFO] M.C.c.a.LoggingAspect - Return : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester2] / Method : [myCarpool] / Status : [200 OK] / Returned : [Message(message=내 카풀 조회, status=200 OK, data=MATE.Carpool.domain.carpool.dto.response.CarpoolWithPassengersDTO@b8c78ab)]
+2025-03-03 02:21:43 [INFO] M.C.c.a.LoggingAspect - Join : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester1] / Method : [getCarpoolHistory] / Args : []
+2025-03-03 02:21:43 [INFO] M.C.c.a.LoggingAspect - Return : IP : [0:0:0:0:0:0:0:1] / MemberId : [tester1] / Method : [getCarpoolHistory] / Status : [200 OK] / Returned : [Message(message=탑승 목록 조회 성공, status=200 OK, data=[])]
+2025-03-03 02:21:47 [INFO] o.s.b.w.e.t.GracefulShutdown - Commencing graceful shutdown. Waiting for active requests to complete
+2025-03-03 02:21:47 [INFO] o.s.b.w.e.t.GracefulShutdown - Graceful shutdown complete
+2025-03-03 02:21:47 [INFO] o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
+2025-03-03 02:21:47 [INFO] c.z.h.HikariDataSource - HikariPool-1 - Shutdown initiated...
+2025-03-03 02:21:47 [INFO] c.z.h.HikariDataSource - HikariPool-1 - Shutdown completed.
+2025-03-03 02:22:03 [INFO] o.h.v.i.u.Version - HV000001: Hibernate Validator 8.0.1.Final
+2025-03-03 02:22:03 [INFO] M.C.CarpoolApplicationTests - Starting CarpoolApplicationTests using Java 17.0.10 with PID 34566 (started by jeonminseo in /Users/jeonminseo/Downloads/Carpool_Last)
+2025-03-03 02:22:03 [INFO] M.C.CarpoolApplicationTests - No active profile set, falling back to 1 default profile: "default"
+2025-03-03 02:22:04 [INFO] o.s.d.r.c.RepositoryConfigurationDelegate - Multiple Spring Data modules found, entering strict repository configuration mode
+2025-03-03 02:22:04 [INFO] o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data JPA repositories in DEFAULT mode.
+2025-03-03 02:22:04 [INFO] o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 80 ms. Found 4 JPA repository interfaces.
+2025-03-03 02:22:04 [INFO] o.s.d.r.c.RepositoryConfigurationDelegate - Multiple Spring Data modules found, entering strict repository configuration mode
+2025-03-03 02:22:04 [INFO] o.s.d.r.c.RepositoryConfigurationDelegate - Bootstrapping Spring Data Redis repositories in DEFAULT mode.
+2025-03-03 02:22:04 [INFO] o.s.d.r.c.RepositoryConfigurationExtensionSupport - Spring Data Redis - Could not safely identify store assignment for repository candidate interface MATE.Carpool.domain.carpool.repository.CarpoolRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
+2025-03-03 02:22:04 [INFO] o.s.d.r.c.RepositoryConfigurationExtensionSupport - Spring Data Redis - Could not safely identify store assignment for repository candidate interface MATE.Carpool.domain.carpool.repository.ReservationRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
+2025-03-03 02:22:04 [INFO] o.s.d.r.c.RepositoryConfigurationExtensionSupport - Spring Data Redis - Could not safely identify store assignment for repository candidate interface MATE.Carpool.domain.member.repository.MemberRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
+2025-03-03 02:22:04 [INFO] o.s.d.r.c.RepositoryConfigurationExtensionSupport - Spring Data Redis - Could not safely identify store assignment for repository candidate interface MATE.Carpool.domain.report.repository.ReportRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
+2025-03-03 02:22:04 [INFO] o.s.d.r.c.RepositoryConfigurationDelegate - Finished Spring Data repository scanning in 5 ms. Found 0 Redis repository interfaces.
+2025-03-03 02:22:04 [INFO] o.h.j.i.u.LogHelper - HHH000204: Processing PersistenceUnitInfo [name: default]
+2025-03-03 02:22:04 [INFO] o.h.Version - HHH000412: Hibernate ORM core version 6.6.2.Final
+2025-03-03 02:22:04 [INFO] o.h.c.i.RegionFactoryInitiator - HHH000026: Second-level cache disabled
+2025-03-03 02:22:04 [INFO] o.s.o.j.p.SpringPersistenceUnitInfo - No LoadTimeWeaver setup: ignoring JPA class transformer
+2025-03-03 02:22:04 [INFO] c.z.h.HikariDataSource - HikariPool-1 - Starting...
+2025-03-03 02:22:04 [INFO] c.z.h.p.HikariPool - HikariPool-1 - Added connection conn0: url=jdbc:h2:mem:test user=SA
+2025-03-03 02:22:04 [INFO] c.z.h.HikariDataSource - HikariPool-1 - Start completed.
+2025-03-03 02:22:04 [WARN] o.h.o.deprecation - HHH90000025: H2Dialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
+2025-03-03 02:22:04 [INFO] o.h.o.c.pooling - HHH10001005: Database info:
+	Database JDBC URL [Connecting through datasource 'HikariDataSource (HikariPool-1)']
+	Database driver: undefined/unknown
+	Database version: 2.3.232
+	Autocommit mode: undefined/unknown
+	Isolation level: undefined/unknown
+	Minimum pool size: undefined/unknown
+	Maximum pool size: undefined/unknown
+2025-03-03 02:22:05 [INFO] o.h.e.t.j.p.i.JtaPlatformInitiator - HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
+2025-03-03 02:22:05 [INFO] o.s.o.j.LocalContainerEntityManagerFactoryBean - Initialized JPA EntityManagerFactory for persistence unit 'default'
+2025-03-03 02:22:05 [INFO] o.s.d.j.r.q.QueryEnhancerFactory - Hibernate is in classpath; If applicable, HQL parser will be used.
+2025-03-03 02:22:06 [ERROR] i.n.r.d.DnsServerAddressStreamProviders - Unable to load io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS. Check whether you have a dependency on 'io.netty:netty-resolver-dns-native-macos'. Use DEBUG level to see the full stack: java.lang.UnsatisfiedLinkError: failed to load the required native library
+2025-03-03 02:22:06 [WARN] o.s.b.a.o.j.JpaBaseConfiguration$JpaWebConfiguration - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
+2025-03-03 02:22:06 [INFO] o.s.s.c.a.a.c.InitializeUserDetailsBeanManagerConfigurer$InitializeUserDetailsManagerConfigurer - Global AuthenticationManager configured with UserDetailsService bean with name customUserDetailsServiceImpl
+2025-03-03 02:22:07 [INFO] o.s.b.a.e.w.EndpointLinksResolver - Exposing 1 endpoint beneath base path '/actuator'
+2025-03-03 02:22:07 [INFO] o.s.b.a.h.H2ConsoleAutoConfiguration - H2 console available at '/h2-console'. Database available at 'jdbc:h2:mem:test'
+2025-03-03 02:22:07 [INFO] M.C.CarpoolApplicationTests - Started CarpoolApplicationTests in 4.46 seconds (process running for 4.975)
+2025-03-03 02:22:07 [INFO] M.C.c.a.LoggingAspect - Join : IP : [Unknown] / Method : [run] / Args : [[[]]]
+2025-03-03 02:22:11 [INFO] o.s.o.j.LocalContainerEntityManagerFactoryBean - Closing JPA EntityManagerFactory for persistence unit 'default'
+2025-03-03 02:22:11 [INFO] c.z.h.HikariDataSource - HikariPool-1 - Shutdown initiated...
+2025-03-03 02:22:11 [INFO] c.z.h.HikariDataSource - HikariPool-1 - Shutdown completed.

--- a/src/main/java/MATE/Carpool/domain/carpool/controller/CarpoolController.java
+++ b/src/main/java/MATE/Carpool/domain/carpool/controller/CarpoolController.java
@@ -61,12 +61,12 @@ public class CarpoolController implements CarpoolApi {
         return carpoolService.reservationCarpool(userDetails, requestDTO);
     }
 
-    @GetMapping("/cancelCarpool")
+    @PostMapping("/cancelCarpool")
     public ResponseEntity<Message<String>> cancelCarpool(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return carpoolService.cancelCarpool(userDetails);
     }
 
-    @GetMapping("/deleteCarpool")
+    @DeleteMapping("/deleteCarpool")
     public ResponseEntity<Message<String>> deleteCarpool(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return carpoolService.deleteCarpool(userDetails);
     }

--- a/src/main/java/MATE/Carpool/domain/carpool/repository/CarpoolRepository.java
+++ b/src/main/java/MATE/Carpool/domain/carpool/repository/CarpoolRepository.java
@@ -29,9 +29,8 @@ public interface CarpoolRepository extends JpaRepository<CarpoolEntity, Long> {
     @Query("SELECT c FROM CarpoolEntity c WHERE c.createdAt > :blockStart ORDER BY c.cost ASC")
     List<CarpoolEntity> findByFastList(@Param("blockStart")LocalDateTime blockStart);
 
-    @Query("SELECT c from CarpoolEntity c where c.member = :member ORDER BY c.departureDateTime DESC")
-    List<CarpoolEntity> findByMemberHis(@Param("member")Member member);
-
+    @Query("SELECT c from CarpoolEntity c where c.member = :member AND c.createdAt < :blockStart ORDER BY c.departureDateTime DESC")
+    List<CarpoolEntity> findByDriverHis(@Param("member")Member member, @Param("blockStart") LocalDateTime blockStart);
 
     @Query("SELECT c FROM CarpoolEntity c WHERE c.createdAt BETWEEN :startDate AND :endDate")
     Page<CarpoolResponseDTO> findByCarpoolToPeriod(Pageable pageable,@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);

--- a/src/main/java/MATE/Carpool/domain/carpool/repository/ReservationRepository.java
+++ b/src/main/java/MATE/Carpool/domain/carpool/repository/ReservationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ReservationRepository extends JpaRepository<ReservationEntity, Long> {
@@ -29,8 +30,8 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
     @Query("delete from ReservationEntity r where r.carpool.id =:carpoolId")
     void deleteCarpool(@Param("carpoolId") Long carpoolId);
 
-    @Query("SELECT r from ReservationEntity r join fetch r.carpool c where r.member = :member ORDER BY c.departureDateTime DESC")
-    List<ReservationEntity> findByCarpoolHis(@Param("member") Member member);
+    @Query("SELECT r from ReservationEntity r join fetch r.carpool c where r.member = :member AND c.createdAt < :blockStart ORDER BY c.departureDateTime DESC")
+    List<ReservationEntity> findByRideCarpoolHis(@Param("member") Member member, @Param("blockStart") LocalDateTime blockStart);
 
 
 //    @Query("select r from ReservationEntity r where r.carpoolId = :carpoolId")

--- a/src/main/java/MATE/Carpool/domain/carpool/service/CarpoolService.java
+++ b/src/main/java/MATE/Carpool/domain/carpool/service/CarpoolService.java
@@ -291,12 +291,14 @@ public class CarpoolService {
     @Transactional(readOnly = true)
     public ResponseEntity<Message<List<CarpoolHistoryResponseDTO>>> getCarpoolHistory(CustomUserDetails userDetails) {
 
+        LocalDateTime blockStart = getBlockStart();
+
         Member member = userDetails.getMember();
 
         List<CarpoolHistoryResponseDTO> result = new ArrayList<>();
 
         //예약에서 목록 가져오기
-        List<ReservationEntity> reservationEntities = reservationRepository.findByCarpoolHis(member);
+        List<ReservationEntity> reservationEntities = reservationRepository.findByRideCarpoolHis(member, blockStart);
         for (ReservationEntity r : reservationEntities) {
             result.add(new CarpoolHistoryResponseDTO(r.getCarpool()));
         }
@@ -307,12 +309,14 @@ public class CarpoolService {
     @Transactional(readOnly = true)
     public ResponseEntity<Message<List<CarpoolHistoryResponseDTO>>> getDriverHistory(CustomUserDetails userDetails) {
 
+        LocalDateTime blockStart = getBlockStart();
+
         Member member = userDetails.getMember();
 
         List<CarpoolHistoryResponseDTO> result = new ArrayList<>();
 
         if (member.getIsDriver()) {
-            List<CarpoolEntity> driverCarpool = carpoolRepository.findByMemberHis(member);
+            List<CarpoolEntity> driverCarpool = carpoolRepository.findByDriverHis(member, blockStart);
             for (CarpoolEntity c : driverCarpool) {
                 result.add(new CarpoolHistoryResponseDTO(c));
             }


### PR DESCRIPTION
### 카풀 취소 및 삭제 HTTP 메서드 변경

**기존:** 
카풀 취소 및 삭제 요청을 GET 메서드로 처리
**변경:**
카풀 취소 → POST 메서드로 변경
카풀 삭제 → DELETE 메서드로 변경

### 카풀 이용 목록 표시 시점 변경

**기존:**
예약 생성 즉시 카풀 이용 목록에 표시
**변경:** 
카풀 종료 후에 카풀 이용 목록에 표시